### PR TITLE
Allow toggling indicator bar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install 'jupyterlab>=3.0.0,<4'
+        run: python -m pip install 'jupyterlab>=4.0.0,<5'
 
       - name: Install the extension
         run: |

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -13,14 +13,19 @@ jobs:
   check_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
       - name: Check Release
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload Distributions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jupyter-resource-usage-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip black 'jupyterlab>=3.0.0,<4'
+          python -m pip install --upgrade pip black 'jupyterlab>=4.0.0,<5'
 
       - name: Lint Python
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.12']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -37,6 +37,6 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bugs fixed
 
-- Force new instance of  `ASyncHTTPclient` [#10](https://github.com/mahendrapaipuri/jupyter-power-usage/pull/10) ([@mahendrapaipuri](https://github.com/mahendrapaipuri))
+- Force new instance of `ASyncHTTPclient` [#10](https://github.com/mahendrapaipuri/jupyter-power-usage/pull/10) ([@mahendrapaipuri](https://github.com/mahendrapaipuri))
 
 ### Contributors to this release
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "jupyter_power_usage"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
@@ -16,10 +16,10 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "jupyterlab>=4.0.0,<5",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -26,6 +26,12 @@
       "default": 5000,
       "type": "number"
     },
+    "indicatorBarDisabled": {
+      "title": "Disable Indicator Bar",
+      "description": "If set to true indicator bar will not be rendered. Only text values will be shown. Useful when working on low resolution screens with a lot of top bar items.",
+      "default": false,
+      "type": "boolean"
+    },
     "cpu": {
       "title": "CPU Power Settings",
       "description": "Settings for the CPU Power indicator",

--- a/src/cpuPowerView.tsx
+++ b/src/cpuPowerView.tsx
@@ -8,9 +8,11 @@ import { PowerUsage } from './model';
 
 const CpuPowerViewComponent = ({
   model,
+  indicatorBarEnabled,
   label,
 }: {
   model: PowerUsage.Model;
+  indicatorBarEnabled: boolean;
   label: string;
 }): ReactElement => {
   const [text, setText] = useState('');
@@ -37,6 +39,7 @@ const CpuPowerViewComponent = ({
   return (
     <IndicatorComponent
       enabled={model.cpuPowerAvailable}
+      indicatorBarEnabled={indicatorBarEnabled}
       values={values}
       label={label}
       color={'#1AB7AE'}
@@ -54,10 +57,15 @@ export namespace CpuPowerView {
    */
   export const createPowerView = (
     model: PowerUsage.Model,
+    indicatorBarEnabled: boolean,
     label: string
   ): ReactWidget => {
     return ReactWidget.create(
-      <CpuPowerViewComponent model={model} label={label} />
+      <CpuPowerViewComponent
+        model={model}
+        indicatorBarEnabled={indicatorBarEnabled}
+        label={label}
+      />
     );
   };
 }

--- a/src/gpuPowerView.tsx
+++ b/src/gpuPowerView.tsx
@@ -8,9 +8,11 @@ import { PowerUsage } from './model';
 
 const GpuPowerViewComponent = ({
   model,
+  indicatorBarEnabled,
   label,
 }: {
   model: PowerUsage.Model;
+  indicatorBarEnabled: boolean;
   label: string;
 }): ReactElement => {
   const [text, setText] = useState('');
@@ -37,6 +39,7 @@ const GpuPowerViewComponent = ({
   return (
     <IndicatorComponent
       enabled={model.gpuPowerAvailable}
+      indicatorBarEnabled={indicatorBarEnabled}
       values={values}
       label={label}
       color={'#76B900'}
@@ -54,10 +57,15 @@ export namespace GpuPowerView {
    */
   export const createPowerView = (
     model: PowerUsage.Model,
+    indicatorBarEnabled: boolean,
     label: string
   ): ReactWidget => {
     return ReactWidget.create(
-      <GpuPowerViewComponent model={model} label={label} />
+      <GpuPowerViewComponent
+        model={model}
+        indicatorBarEnabled={indicatorBarEnabled}
+        label={label}
+      />
     );
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,11 @@ import '../style/index.css';
 const DEFAULT_RAPL_REFRESH_RATE = 5000;
 
 /**
+ * By default indicator bar is always enabled.
+ */
+const DEFAULT_INDICATOR_BAR_DISABLED = false;
+
+/**
  * The default cpu power label.
  */
 const DEFAULT_CPU_POWER_LABEL = 'CPU Power: ';
@@ -88,6 +93,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     console.log('@mahendrapaipuri/jupyter-power-usage extension is activated');
 
     let refreshRate = DEFAULT_RAPL_REFRESH_RATE;
+    let indicatorBarDisabled = DEFAULT_INDICATOR_BAR_DISABLED;
     let cpuPowerLabel = DEFAULT_CPU_POWER_LABEL;
     let gpuPowerLabel = DEFAULT_GPU_POWER_LABEL;
     let emissionsRefreshRate = DEFAULT_EMISSIONS_REFRESH_RATE;
@@ -105,6 +111,10 @@ const extension: JupyterFrontEndPlugin<void> = {
         );
         refreshRate = DEFAULT_RAPL_REFRESH_RATE;
       }
+
+      indicatorBarDisabled = settings.get('indicatorBarDisabled')
+        .composite as boolean;
+
       const emissionsSettings = settings.get('emissions')
         .composite as IEmissionsSettings;
       emissionFactorSource = emissionsSettings.source;
@@ -118,6 +128,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         );
         emissionsRefreshRate = DEFAULT_EMISSIONS_REFRESH_RATE;
       }
+
       const cpuSettings = settings.get('cpu').composite as IResourceSettings;
       cpuPowerLabel = cpuSettings.label;
       const gpuSettings = settings.get('gpu').composite as IResourceSettings;
@@ -148,7 +159,11 @@ const extension: JupyterFrontEndPlugin<void> = {
     // Add cpu power usage panel if metrics are available
     if (model.cpuPowerAvailable) {
       toolbarRegistry.addFactory('TopBar', 'cpu_power', () => {
-        const cpuPower = CpuPowerView.createPowerView(model, cpuPowerLabel);
+        const cpuPower = CpuPowerView.createPowerView(
+          model,
+          !indicatorBarDisabled,
+          cpuPowerLabel
+        );
         return cpuPower;
       });
     }
@@ -156,7 +171,11 @@ const extension: JupyterFrontEndPlugin<void> = {
     // Add gpu power usage panel if metrics are available
     if (model.gpuPowerAvailable) {
       toolbarRegistry.addFactory('TopBar', 'gpu_power', () => {
-        const gpuPower = GpuPowerView.createPowerView(model, gpuPowerLabel);
+        const gpuPower = GpuPowerView.createPowerView(
+          model,
+          !indicatorBarDisabled,
+          gpuPowerLabel
+        );
         return gpuPower;
       });
     }

--- a/src/indicator.tsx
+++ b/src/indicator.tsx
@@ -5,6 +5,13 @@ import { Sparklines, SparklinesLine, SparklinesSpots } from 'react-sparklines';
 /**
  * A indicator fill component.
  */
+function getColor(value: number, baseColor: string): string {
+  return value > 0.5 ? (value > 0.8 ? 'red' : 'orange') : baseColor;
+}
+
+/**
+ * A indicator fill component.
+ */
 const IndicatorFiller = ({
   percentage,
   color,
@@ -41,8 +48,7 @@ const IndicatorBar = ({
     setIsSparklines(!isSparklines);
   };
 
-  const color =
-    percentage > 0.5 ? (percentage > 0.8 ? 'red' : 'orange') : baseColor;
+  const color = getColor(percentage, baseColor);
 
   return (
     <div className="jp-IndicatorBar" onClick={(): void => toggleSparklines()}>
@@ -78,23 +84,26 @@ const IndicatorBar = ({
  */
 export const IndicatorComponent = ({
   enabled,
+  indicatorBarEnabled,
   values,
   label,
   color,
   text,
 }: {
   enabled: boolean;
+  indicatorBarEnabled: boolean;
   values: number[];
   label: string;
   color: string;
   text: string;
 }): ReactElement => {
   const percentage = values[values.length - 1];
+  const textColor = getColor(percentage, color);
   return (
     enabled && (
       <div className="jp-IndicatorContainer">
         <div className="jp-IndicatorText">{label}</div>
-        {percentage !== null && (
+        {percentage !== null && indicatorBarEnabled && (
           <div className="jp-IndicatorWrapper">
             <IndicatorBar
               values={values}
@@ -103,7 +112,12 @@ export const IndicatorComponent = ({
             />
           </div>
         )}
-        <div className="jp-IndicatorText">{text}</div>
+        <div
+          className="jp-IndicatorText"
+          style={{ color: !indicatorBarEnabled && textColor }}
+        >
+          {text}
+        </div>
       </div>
     )
   );


### PR DESCRIPTION
* When working on low resolution screens with a lot of top bar components, the components can overlap the notebook making it harder to work.

* This commit introduces a configurable toggle to disable indicator bars to save space. When indicator bars are disabled, the text will be rendered with color based on usage percentage to still attract user's attention