### PR TITLE
Pass standby callback to polling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
+  JupyterLab,
 } from '@jupyterlab/application';
 
 import { IToolbarWidgetRegistry } from '@jupyterlab/apputils';
@@ -84,11 +85,12 @@ const extension: JupyterFrontEndPlugin<void> = {
   id: '@mahendrapaipuri/jupyter-power-usage:plugin',
   autoStart: true,
   requires: [IToolbarWidgetRegistry],
-  optional: [ISettingRegistry],
+  optional: [ISettingRegistry, JupyterLab.IInfo],
   activate: async (
     app: JupyterFrontEnd,
     toolbarRegistry: IToolbarWidgetRegistry,
-    settingRegistry: ISettingRegistry | null
+    settingRegistry: ISettingRegistry | null,
+    info: JupyterLab.IInfo | null
   ) => {
     console.log('@mahendrapaipuri/jupyter-power-usage extension is activated');
 
@@ -143,10 +145,24 @@ const extension: JupyterFrontEndPlugin<void> = {
       },
       countryCode: countryCode,
       defaultEmissionFactor: emissionFactor,
+      refreshStandby: () => {
+        if (info) {
+          return !info.isConnected || 'when-hidden';
+        }
+        return 'when-hidden';
+      },
     });
     await emissionsModel.refresh();
 
-    const model = new PowerUsage.Model(emissionsModel, { refreshRate });
+    const model = new PowerUsage.Model(emissionsModel, {
+      refreshRate,
+      refreshStandby: () => {
+        if (info) {
+          return !info.isConnected || 'when-hidden';
+        }
+        return 'when-hidden';
+      },
+    });
     await model.refresh();
 
     // Dispose poll if none of the metrics are available

--- a/src/model.ts
+++ b/src/model.ts
@@ -47,9 +47,12 @@ export namespace PowerUsage {
         frequency: {
           interval: options.refreshRate,
           backoff: true,
+          max: 300 * 1000,
         },
         name: 'jupyter-power-usage:PowerUsage#metrics',
+        standby: options.refreshStandby || 'when-hidden',
       });
+
       this._poll.ticked.connect((poll) => {
         const { payload, phase } = poll.state;
         if (phase === 'resolved') {
@@ -280,6 +283,11 @@ export namespace PowerUsage {
        * The refresh rate (in ms) for querying the server.
        */
       refreshRate: number;
+
+      /**
+       * When the model stops polling the API. Defaults to `when-hidden`.
+       */
+      refreshStandby?: Poll.Standby | (() => boolean | Poll.Standby);
     }
 
     /**
@@ -357,8 +365,10 @@ export namespace EmissionFactor {
         frequency: {
           interval: options.refreshRate,
           backoff: true,
+          max: 300 * 1000,
         },
         name: 'jupyter-power-usage:EmissionFactor#metrics',
+        standby: options.refreshStandby || 'when-hidden',
       });
       this._poll.ticked.connect((poll) => {
         const { payload, phase } = poll.state;
@@ -476,6 +486,11 @@ export namespace EmissionFactor {
        * Default emissions factor that will be used in case of unavailable data
        */
       defaultEmissionFactor: number;
+
+      /**
+       * When the model stops polling the API. Defaults to `when-hidden`.
+       */
+      refreshStandby?: Poll.Standby | (() => boolean | Poll.Standby);
     }
   }
 }


### PR DESCRIPTION
* When server stops, the standby callback will return true which stops the polling mechanism to not execute factory callback. This is relevant in JupyterHub deployments where terminated servers will keep making API requests which pollute the logs.